### PR TITLE
Fix: Adjust KaTeX script loading order in app1_explorador_pilares.html

### DIFF
--- a/app1_explorador_pilares.html
+++ b/app1_explorador_pilares.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="css/style.css"> 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css" integrity="sha384-wcIxkf4k55AIcd2uy7g7WpVfAUcSwrrFRU8TTWELU7Ld84QCJWAARekL7SgMRSuB" crossorigin="anonymous">
     <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js" integrity="sha384-hIoBPJpTUs74ddyc4bFZSM1gAUAAN5CRbMpbgotgjMHHJaTDCB1UeFCAfPTL4VKB" crossorigin="anonymous"></script>
-    <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js" integrity="sha384-gMqMDRY31GPoApRNGbAVH8yLQD9Iok9RzP72rYF6A734zZwo7rX/rXAAUa7qJjxH" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js" integrity="sha384-gMqMDRY31GPoApRNGbAVH8yLQD9Iok9RzP72rYF6A734zZwo7rX/rXAAUa7qJjxH" crossorigin="anonymous"></script>
     <style>
         /* Estilos adicionais para a página app1 (mantidos da versão anterior) */
         .intro-video-section {


### PR DESCRIPTION
I removed the 'defer' attribute from the `auto-render.min.js` script tag. This aims to resolve an issue where KaTeX formulas were not rendering due to the `renderMathInElement` function being unavailable when the DOMContentLoaded event fired. By ensuring `auto-render.min.js` loads synchronously in its position, the rendering function should be defined when the subsequent script attempts to use it.